### PR TITLE
Tokenize on byte offsets instead of character indexes

### DIFF
--- a/md_parser/src/lexer.rs
+++ b/md_parser/src/lexer.rs
@@ -68,11 +68,6 @@ impl<'a> Lexer<'a> {
         match c {
             Some(c) => {
                 if c.is_ascii() {
-                    println!(
-                        "symbol={} contains={}",
-                        c as char,
-                        SYMBOLS.contains(c as char)
-                    );
                     c.is_ascii_digit() || SYMBOLS.contains(c as char)
                 } else {
                     false
@@ -86,20 +81,11 @@ impl<'a> Lexer<'a> {
         let start_offset = self.current_byte_offset - 1;
         let mut end_byte_offset = start_offset;
         while !self.is_at_end() && !self.is_token(self.peek()) {
-            let value = self.advance();
-            println!(
-                "Advancing a byte value={:#?} peek={:#?}",
-                value.map(|c| c as char),
-                self.peek().map(|c| c as char)
-            );
+            self.advance();
             end_byte_offset += 1;
         }
 
         let value = &self.source[start_offset..end_byte_offset + 1];
-        println!(
-            "value={} start={} end={}",
-            value, start_offset, end_byte_offset
-        );
 
         self.add_token(Token::Text(value));
     }

--- a/web_repl/src/main.rs
+++ b/web_repl/src/main.rs
@@ -6,7 +6,7 @@ use md_parser::renderer::render_html;
 
 const INITIAL_MD: &str = r"## Hello from Gohan!
 
-Gohan is a [Rust-based](https://www.rust-lang.org/) markdown parser and HTML compiler.
+Gohan is a [Rust-based 🦀](https://www.rust-lang.org/) markdown parser and HTML compiler.
 Give it a **try!**.
 ";
 


### PR DESCRIPTION
## Description

I was initially indexing on characters assuming everything was ASCII (one byte per char), but this is an obvious problem in rust where the `&str` type guarantees UTF-8 encoding and some characters are longer than one byte, which throws a spanner in the works when I do something like `source[idx]` which in this case indexes on the byte-offset of the character and it would panic with something like:

```shell
thread 'rustc' panicked at 'byte index 4 is not a char boundary; it is inside '🤡' (bytes 0..4) of...'
```

By indexing on byte offsets, I can safely rely on ASCII as usual within the UTF-8 encoded strings to look-up for Markdown symbols, but still handle multi-byte characters like emojis as normal text.

### A bit on graphemes and Grapheme clusters

A grapheme cluster is a sequence of one or more Unicode code points that should be treated as a single unit by various processes. This is specially important for emojis where multiple emojis can form a different grapheme cluster.

Let's take this example into account:

```rust
use unicode_width::UnicodeWidthStr;

fn main() {
    let family = "👨‍👩‍👦";
    println!("{} {}", family.width_cjk(), UnicodeWidthStr::width(family));
    println!("{family}");
    println!("{:X<width$}", "", width = family.width_cjk());
}
```

The `family` variable is actually a combination of the following emojis:
- [x] 👨
- [x] 👩
- [x] 👶

And when they are followed in this order, they should render the "👨‍👩‍👦" emoji instead with a width of 6. And the emojis on themselves are represented as multi-byte characters.

#### Reading Material

Joel Spolsky has a a really good article about this here:
- [x] [The Absolute Minimum Every Software Developer Absolutely, Positively Must Know About Unicode and Character Sets (No Excuses!)](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/)

Rust lang forum thread with some tips on how to handle this.
- [x] [Tracking position in unicode-enabled lexer, best practice?](https://users.rust-lang.org/t/tracking-position-in-unicode-enabled-lexer-best-practice/95340)